### PR TITLE
Config command implementation, run wip

### DIFF
--- a/cmd/cmd-config.go
+++ b/cmd/cmd-config.go
@@ -19,8 +19,12 @@ var argcmp = [][]string{{"global", "target", "path"}, {"use", "global", "target"
 var configCmd = &cobra.Command{
 	Use: "cfg [ optionName optionValue ] ...",
 	// ValidArgs - names/altnames for every config to be modified
-	ValidArgs: []cobra.Completion{"globaltarget", "globaltargetpath", "path", "useGlobalTarget"},
-
+	// WARNING: Probably need to delete?
+	ValidArgs: []cobra.Completion{"true", "false",
+		"KeepHidden", "KeepRepo", "UseGlobalTarget",
+		"CopyFiles", "CopyAllDirs", "GlobalTargetPath",
+		"keephidden", "keeprepo", "useglobaltarget",
+		"copyfiles", "copyalldirs", "globaltargetpath"},
 	Short: "Modify spec overrides and global config values",
 	Long: `Change dotstrike configuration options as well as spec config options.
 cfg expects arguments in pairs, with each pair containing:
@@ -37,13 +41,50 @@ func cfgRun(cmd *cobra.Command, args []string) {
 	case la == 0 && !*pFlags.global:
 		cfgPrintSelectedSpec(cmd)
 		cfgPrintFlagSpecs(cmd)
-
 	case la == 0:
 		cfgPrintGlobalPrefs(cmd)
-
 	case *pFlags.global && len(args) >= 2: //apply args to global config
 	case len(args) >= 2:
+
 	}
+}
+
+func cfgSpecApply(cmd *cobra.Command, args []string) {
+	temp := dscore.TempData()
+	specs := getSpecs(cmd, !*cfgFlagNoSelect)
+	var confirmUser bool
+	if ls := len(specs); ls > 1 {
+		confirmUser = checkConfirm(fmt.Sprintf("Apply Overrides to %d specs", ls), cfgFlagY)
+	} else if ls == 1 {
+		confirmUser = true
+	}
+	if confirmUser {
+		for i := range specs {
+			e := temp.SetSpecOverridesMap(specs[i], cfgArgsMap(args))
+			if e != nil {
+
+			}
+		}
+	}
+}
+
+// cfgArgsMap creates a map out of an argument list that can be used in SetSpecOverridesMap.
+//
+// It assumes that args is formatted as a linear slice of string:"bool" key value pairs
+//   - even index values (args[i]) are treated as a string key (representing a ConfigOption)
+//   - the next index value ( args[i+1]) will be used as the bool value for that key.
+//
+// If a string cannot be transformed into a bool true/false, the key/value will be discarded.
+func cfgArgsMap(args []string) map[string]bool {
+	M := make(map[string]bool, len(args)/2)
+	_ = M
+	for i := 0; i < len(args)-1; i += 2 {
+		btry := dscore.StringToBool(args[i+1])
+		if btry != nil {
+			M[args[i]] = *btry
+		}
+	}
+	return M
 }
 
 func cfgGlobalApply(cmd *cobra.Command, args []string) {
@@ -51,7 +92,7 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 	for i := 0; i < len(args)-1; i += 2 {
 		opt := dscore.OptionID(args[i])
 		switch {
-		case dscore.IsBoolOption(opt):
+		case dscore.OptionIsBool(opt):
 			barg := dscore.StringToBool(args[i+1])
 			if barg != nil {
 				output := textOptionModified(opt.Text(), temp.SetOptionBool(opt, *barg))
@@ -60,7 +101,7 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 				cmd.Printf("Failed. Cannot convert '%s' to true/false.", args[i+1])
 			}
 
-		case dscore.IsStringOption(opt): // unnecessarily messy
+		case dscore.OptionIsString(opt): // unnecessarily messy
 			cfgApplyGlobalTargetCautious(cmd, args[i+1])
 		}
 	}
@@ -71,9 +112,9 @@ func cfgApplyGlobalTargetCautious(cmd *cobra.Command, newpath string) {
 	temp := dscore.TempData()
 	exist, e := pops.PathExists(newpath)
 	if e != nil {
-		y = checkConfirm("Error checking path. Set as Global Target path anyway", flagConfirm)
+		y = checkConfirm("Error checking path. Set as Global Target path anyway", cfgFlagY)
 	} else if !exist {
-		y = checkConfirm("Path does not exist or was not found. Set as Global Target path anyway", flagConfirm)
+		y = checkConfirm("Path does not exist or was not found. Set as Global Target path anyway", cfgFlagY)
 	} else {
 		y = true
 	}
@@ -129,7 +170,7 @@ func textOptionModified(val string, modified bool) string {
 
 }
 
-var flagConfirm *bool
+var cfgFlagY, cfgFlagNoSelect *bool
 
 type cfgOpt int
 
@@ -146,7 +187,8 @@ func makeValid(argcomponents [][]string) []string {
 
 func init() {
 	rootCmd.AddCommand(configCmd)
-	flagConfirm = configCmd.Flags().BoolP("confirm", "y", false, "--confirm/-y")
+	cfgFlagY = configCmd.Flags().BoolP("confirm", "y", false, "--confirm/-y")
+	cfgFlagNoSelect = configCmd.Flags().Bool("noselect", false, "disable all action on selected spec")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/cmd-config.go
+++ b/cmd/cmd-config.go
@@ -51,7 +51,7 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 	for i := 0; i < len(args)-1; i += 2 {
 		opt := dscore.OptionID(args[i])
 		switch opt {
-		case dscore.OptBoolKeepRepo, dscore.OptBoolKeepHidden, dscore.OptBoolUseGlobalTarget:
+		case dscore.OptBkeepRepo, dscore.OptBKeepHidden, dscore.OptBUseGlobalTgt:
 			barg := dscore.StringToBool(args[i+1])
 			if barg != nil {
 				output := textOptionModified(opt.Text(), temp.SetOptionBool(opt, *barg))
@@ -60,7 +60,7 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 				cmd.Printf("Failed. Cannot convert '%s' to true/false.", args[i+1])
 			}
 
-		case dscore.OptStringGlobalTargetPath: // unnecessarily messy
+		case dscore.OptSGlobalTargetPath: // unnecessarily messy
 			cfgApplyGlobalTargetCautious(cmd, args[i+1])
 		}
 	}
@@ -78,7 +78,7 @@ func cfgApplyGlobalTargetCautious(cmd *cobra.Command, newpath string) {
 		y = true
 	}
 	if y {
-		e = temp.SetOptionString(dscore.OptStringGlobalTargetPath, newpath)
+		e = temp.SetOptionString(dscore.OptSGlobalTargetPath, newpath)
 		if e != nil {
 			cmd.Printf("Error converting path '%s' to absolute path", newpath)
 		}

--- a/cmd/cmd-config.go
+++ b/cmd/cmd-config.go
@@ -50,8 +50,8 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 	temp := dscore.TempData()
 	for i := 0; i < len(args)-1; i += 2 {
 		opt := dscore.OptionID(args[i])
-		switch opt {
-		case dscore.OptBkeepRepo, dscore.OptBKeepHidden, dscore.OptBUseGlobalTgt:
+		switch {
+		case dscore.IsBoolOption(opt):
 			barg := dscore.StringToBool(args[i+1])
 			if barg != nil {
 				output := textOptionModified(opt.Text(), temp.SetOptionBool(opt, *barg))
@@ -60,7 +60,7 @@ func cfgGlobalApply(cmd *cobra.Command, args []string) {
 				cmd.Printf("Failed. Cannot convert '%s' to true/false.", args[i+1])
 			}
 
-		case dscore.OptSGlobalTargetPath: // unnecessarily messy
+		case dscore.IsStringOption(opt): // unnecessarily messy
 			cfgApplyGlobalTargetCautious(cmd, args[i+1])
 		}
 	}

--- a/cmd/cmd-config.go
+++ b/cmd/cmd-config.go
@@ -24,7 +24,7 @@ var configCmd = &cobra.Command{
 		"KeepHidden", "KeepRepo", "UseGlobalTarget",
 		"CopyFiles", "CopyAllDirs", "GlobalTargetPath",
 		"keephidden", "keeprepo", "useglobaltarget",
-		"copyfiles", "copyalldirs", "globaltargetpath"},
+		"copyfiles", "copyalldirs", "globaltargetpath", "override"},
 	Short: "Modify spec overrides and global config values",
 	Long: `Change dotstrike configuration options as well as spec config options.
 cfg expects arguments in pairs, with each pair containing:
@@ -35,6 +35,8 @@ To modify global config options, use the --global flag`,
 	Run: cfgRun,
 }
 
+//TODO: This will just be way easier if it's a struct
+
 func cfgRun(cmd *cobra.Command, args []string) {
 	la := len(args)
 	switch {
@@ -44,47 +46,94 @@ func cfgRun(cmd *cobra.Command, args []string) {
 	case la == 0:
 		cfgPrintGlobalPrefs(cmd)
 	case *pFlags.global && len(args) >= 2: //apply args to global config
-	case len(args) >= 2:
+		cfgGlobalApply(cmd, args)
 
+	case len(args) >= 2:
+		good := cfgSpecApply(cmd, args)
+		if !good {
+			cfgPrintErrHelp(cmd)
+		}
 	}
 }
+func cfgPrintErrHelp(cmd *cobra.Command) {
+	cmd.Println("check cfg --help for argument info")
+}
 
-func cfgSpecApply(cmd *cobra.Command, args []string) {
+// return == outcome match user intent;
+func cfgSpecApply(cmd *cobra.Command, args []string) bool {
 	temp := dscore.TempData()
 	specs := getSpecs(cmd, !*cfgFlagNoSelect)
 	var confirmUser bool
 	if ls := len(specs); ls > 1 {
-		confirmUser = checkConfirm(fmt.Sprintf("Apply Overrides to %d specs", ls), cfgFlagY)
+		confirmUser = checkConfirm(fmt.Sprintf("Apply Options (overrides) to %d specs", ls), cfgFlagY)
 	} else if ls == 1 {
 		confirmUser = true
+	} else if ls == 0 {
+		return false
 	}
 	if confirmUser {
+		mapargs, remainder := cfgArgsMap(args)
+		lr := len(remainder)
+		cfgOutRemainder(cmd, remainder)
+		if lr > 0 {
+			cfgOutRemainder(cmd, remainder)
+		}
+		if len(mapargs) == 0 {
+			cmd.Print("Failed")
+			return false
+		}
 		for i := range specs {
-			e := temp.SetSpecOverridesMap(specs[i], cfgArgsMap(args))
-			if e != nil {
-
+			failed := temp.SetSpecOverridesMap(specs[i], mapargs)
+			lf := len(failed)
+			if lf > 0 {
+				cmd.Printf("config options not found for:\n%s", failed)
 			}
+			switch {
+			case lf == 0 && lr == 0:
+				cmd.Print("Succesfully wrote all values")
+			case lf*2+lr < len(args):
+				cmd.Print("Succesfully wrote (with failures)")
+			}
+		}
+	}
+	return true
+}
+
+func cfgOutRemainder(cmd *cobra.Command, remainder []string) {
+	lr := len(remainder)
+	if !isEven(lr) {
+		cmd.Printf("unpaired key '%s' not used", remainder[lr-1])
+	}
+	if lr > 2 {
+		cmd.Println("cannot make true/false for:")
+		for i := range lr / 2 {
+			cmd.Printf("%s = '%s'", remainder[i*2], remainder[i*2+1])
 		}
 	}
 }
 
 // cfgArgsMap creates a map out of an argument list that can be used in SetSpecOverridesMap.
+// Returns the created map, and a string slice containing any values that could not be added to the map.
 //
 // It assumes that args is formatted as a linear slice of string:"bool" key value pairs
-//   - even index values (args[i]) are treated as a string key (representing a ConfigOption)
-//   - the next index value ( args[i+1]) will be used as the bool value for that key.
 //
-// If a string cannot be transformed into a bool true/false, the key/value will be discarded.
-func cfgArgsMap(args []string) map[string]bool {
+//	i.e. []string{"opt1","true","opt2","false"} -> map[string]bool{"opt1":true,"opt2":false}
+//
+// If a value cannot be converted to a bool, both key/value arg will be added to the remainder.
+// If the final key has no corresponding value (when len(args) is odd), that key will also be added to remainder.
+func cfgArgsMap(args []string) (map[string]bool, []string) {
+	remainder := make([]string, 0, len(args))
 	M := make(map[string]bool, len(args)/2)
 	_ = M
 	for i := 0; i < len(args)-1; i += 2 {
 		btry := dscore.StringToBool(args[i+1])
 		if btry != nil {
 			M[args[i]] = *btry
+		} else {
+			remainder = append(remainder, args[i], args[i+1])
 		}
 	}
-	return M
+	return M, remainder
 }
 
 func cfgGlobalApply(cmd *cobra.Command, args []string) {

--- a/cmd/cmd-run.go
+++ b/cmd/cmd-run.go
@@ -4,6 +4,8 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"iidexic.dotstrike/dscore"
 )
@@ -15,6 +17,7 @@ type runner struct {
 	flagY, flagNoSelectedSpec, flagAll *bool
 	flagNoFiles, flagAllDir            *bool
 	flagOverrides                      *[]string
+	specNames                          []string
 }
 
 var mainRun runner
@@ -28,23 +31,33 @@ var runCmd = &cobra.Command{
 }
 
 func (r *runner) run(cmd *cobra.Command, args []string) {
-	// 2 lines in and it's already wack, what even is this
-	mainRun = runner{Command: cmd, flagY: r.flagY, flagOverrides: r.flagOverrides}
-	r = &mainRun //lets just call this forced singleton pattern :)
+	r.Command = cmd
+	r.args = args
+	r.specNames = make([]string, 0, len(args))
 	r.specs = r.makeSpecList()
+	if len(r.specs) > 0 {
+		conf := oneSpecOrUserConfirm("Copy Multiple Specs: "+strings.Join(r.specNames, ", "), r.specs)
+		if conf {
+
+		}
+	}
 }
 
 func (r *runner) makeSpecList() []*dscore.Spec {
 	listAlias := *pFlags.spec
+	// reason for not writing directly to r.specs??
 	specs := make([]*dscore.Spec, 0, len(listAlias)+1)
 	temp := dscore.TempData()
 	if !*r.flagNoSelectedSpec {
-		specs = append(specs, temp.SelectedSpec())
+		ss := temp.SelectedSpec()
+		specs = append(specs, ss)
+		r.specNames = append(r.specNames, ss.Alias)
 	}
 	for _, alias := range listAlias {
 		s := temp.GetSpec(alias)
 		if s != nil {
 			specs = append(specs, s)
+			r.specNames = append(r.specNames, s.Alias)
 		}
 	}
 	return specs

--- a/cmd/cmd-source.go
+++ b/cmd/cmd-source.go
@@ -36,7 +36,7 @@ var srcCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		src = cmdWrapper{Command: cmd, args: args} //WIP/FUTURE IMPLEMENTATION
-		affectedSpecs := getSpecs(cmd)
+		affectedSpecs := getSpecs(cmd, true)
 		detail, oneOrMoreExist := detailsIfArgsExist(args, affectedSpecs)
 		numargs, numspecs := len(args), len(affectedSpecs)
 		switch {
@@ -88,7 +88,9 @@ func oneSpecOrUserConfirm(requestText string, specs []*dscore.Spec) bool {
 	return ls == 1 || (ls > 1 && checkConfirm(requestText, srcF.y))
 }
 
-func getSpecs(cmd *cobra.Command) []*dscore.Spec {
+// !!TODO:(HIGHEST:FIX) DECIDE + IMPLEMENT IF GETSPECS INHERENTLY INCLUDES SELECTED & IF GETSPECS PROCESSES NOSELECT
+// getSpecs compiles the list of specs from args of the spec flag
+func getSpecs(cmd *cobra.Command, includeSelected bool) []*dscore.Spec {
 	specs := []*dscore.Spec{}
 	if pFlags.bspec {
 		for _, a := range *pFlags.spec {
@@ -98,7 +100,8 @@ func getSpecs(cmd *cobra.Command) []*dscore.Spec {
 				cmd.Printf("spec %s not found\n", a)
 			}
 		}
-	} else {
+	}
+	if includeSelected {
 		specs = append(specs, dscore.TempData().SelectedSpec())
 	}
 	return specs

--- a/cmd/cmd-target.go
+++ b/cmd/cmd-target.go
@@ -24,7 +24,7 @@ var tgtCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		tgt = cmdWrapper{Command: cmd, args: args} //WIP/FUTURE IMPLEMENTATION
-		affectedSpecs := getSpecs(cmd)
+		affectedSpecs := getSpecs(cmd, true)
 		detail, oneOrMoreExist := detailsIfArgsExist(args, affectedSpecs)
 		numargs, numspecs := len(args), len(affectedSpecs)
 		switch {

--- a/cmd/util_functions.go
+++ b/cmd/util_functions.go
@@ -42,3 +42,5 @@ func stripFalse(list []any, keep []bool) {
 
 	}
 }
+
+func isEven(n int) bool { return n%2 == 0 }

--- a/dscore/Execute.go
+++ b/dscore/Execute.go
@@ -66,9 +66,9 @@ var hardCopyOverride *prefs = &prefs{}
 var useHardOverride bool = false
 
 var overrideWhat = map[ConfigOption]bool{
-	OptBoolKeepHidden:      false,
-	OptBoolKeepRepo:        false,
-	OptBoolUseGlobalTarget: false,
+	OptBKeepHidden:   false,
+	OptBkeepRepo:     false,
+	OptBUseGlobalTgt: false,
 }
 
 func MakeHardOverride() *prefs {
@@ -79,11 +79,11 @@ func MakeHardOverride() *prefs {
 
 func SetHardOverride(boolOpt ConfigOption, value bool) bool {
 	switch boolOpt {
-	case OptBoolKeepRepo:
+	case OptBkeepRepo:
 		hardCopyOverride.KeepRepo = value
-	case OptBoolKeepHidden:
+	case OptBKeepHidden:
 		hardCopyOverride.KeepHidden = value
-	case OptBoolUseGlobalTarget:
+	case OptBUseGlobalTgt:
 		hardCopyOverride.GlobalTarget = value
 	}
 	return false

--- a/dscore/Execute.go
+++ b/dscore/Execute.go
@@ -9,10 +9,11 @@ import (
 
 //TODO: Make Run command non-persistently modify spec prefs for hard overrides/one-time overrides
 
-func (S *Spec) RunCopy(hardOverride *prefs) error {
-	if useHardOverride {
+func BuildCopyJobs() {
 
-	}
+}
+func (S *Spec) RunCopy(hardOverride *prefs) error {
+	//NOTE: Where do jobconfig? within makeCopyJobs?
 	if !S.allInitialized() {
 		return fmt.Errorf("spec not initialized: %s", S.Alias)
 	}
@@ -26,24 +27,33 @@ func (S *Spec) makeCopyJobs() error {
 	for x := range S.Sources {
 		for y := range S.Targets {
 			job := S.newCopyJob(x, y)
+			jobprefs := S.makeJobConfig()
+			if jobprefs != nil {
+
+			}
 			S.applyJobConfig(job)
 		}
 	}
 	return nil
 }
 
+func (S *Spec) makeJobConfig() *prefs {
+
+	return nil
+}
+
 func (S *Spec) applyJobConfig(job *pops.CopyJob) *pops.CopyJob {
-	var p prefs
+	var runPrefs prefs
 	if S.OverrideOn {
-		p = S.Overrides
+		runPrefs = S.Overrides
 	} else {
-		p = gd.data.Prefs
+		runPrefs = gd.data.Prefs
 	}
 
-	if p.bools[OptBUseGlobalTgt] {
+	if runPrefs.bools[OptBUseGlobalTgt] {
 		job.JobOptionMakeSubdir(true)
 	}
-	if p.bools[OptBKeepRepo] {
+	if !runPrefs.bools[OptBKeepRepo] {
 		job.IgnoreGit()
 	}
 
@@ -62,22 +72,28 @@ func (S *Spec) jobName(isrc, itgt int) string {
 	return fmt.Sprintf("%s.src-%d.tgt-%d", S.Alias, isrc, itgt)
 }
 
-// For runtime override flag use.
-var hardCopyOverride *prefs = &prefs{}
-var useHardOverride bool = false
-
-var overrideWhat []bool = make([]bool, len(BoolOptions))
-
-func MakeHardOverride() *prefs {
-	// Add all options to the map, with their existing values in global (or spec if overrides already on)
-	useHardOverride = true
-	return hardCopyOverride
+type runtimeOverride struct {
+	//*prefs //maybe we just add to map only what we do want to force
+	options map[ConfigOption]bool
+	on      bool
 }
+
+var hardOverrides = runtimeOverride{options: make(map[ConfigOption]bool), on: false} //unnecessary initialize?
+// For runtime override flag use.
+// var hardCopyOverride *prefs = &prefs{}
+// var useHardOverride bool = false
+//
+// var overrideWhat []bool = make([]bool, len(BoolOptions))
+//
+// func MakeHardOverride() *prefs {
+// 	// Add all options to the map, with their existing values in global (or spec if overrides already on)
+// 	useHardOverride = true
+// 	return hardCopyOverride
+// }
 
 func SetHardOverride(boolOpt ConfigOption, value bool) bool {
 	if slices.Contains(BoolOptions, boolOpt) {
-		hardCopyOverride.bools[boolOpt] = value
-
+		hardOverrides.options[boolOpt] = value
 		return true
 	}
 

--- a/dscore/Execute.go
+++ b/dscore/Execute.go
@@ -2,6 +2,7 @@ package dscore
 
 import (
 	"fmt"
+	"slices"
 
 	pops "iidexic.dotstrike/pathops"
 )
@@ -39,10 +40,10 @@ func (S *Spec) applyJobConfig(job *pops.CopyJob) *pops.CopyJob {
 		p = gd.data.Prefs
 	}
 
-	if p.GlobalTarget {
+	if p.bools[OptBUseGlobalTgt] {
 		job.JobOptionMakeSubdir(true)
 	}
-	if p.KeepRepo {
+	if p.bools[OptBKeepRepo] {
 		job.IgnoreGit()
 	}
 
@@ -65,11 +66,7 @@ func (S *Spec) jobName(isrc, itgt int) string {
 var hardCopyOverride *prefs = &prefs{}
 var useHardOverride bool = false
 
-var overrideWhat = map[ConfigOption]bool{
-	OptBKeepHidden:   false,
-	OptBkeepRepo:     false,
-	OptBUseGlobalTgt: false,
-}
+var overrideWhat []bool = make([]bool, len(BoolOptions))
 
 func MakeHardOverride() *prefs {
 	// Add all options to the map, with their existing values in global (or spec if overrides already on)
@@ -78,13 +75,11 @@ func MakeHardOverride() *prefs {
 }
 
 func SetHardOverride(boolOpt ConfigOption, value bool) bool {
-	switch boolOpt {
-	case OptBkeepRepo:
-		hardCopyOverride.KeepRepo = value
-	case OptBKeepHidden:
-		hardCopyOverride.KeepHidden = value
-	case OptBUseGlobalTgt:
-		hardCopyOverride.GlobalTarget = value
+	if slices.Contains(BoolOptions, boolOpt) {
+		hardCopyOverride.bools[boolOpt] = value
+
+		return true
 	}
+
 	return false
 }

--- a/dscore/Execute_test.go
+++ b/dscore/Execute_test.go
@@ -3,7 +3,7 @@ package dscore
 import "testing"
 
 func TestTempAssign(t *testing.T) {
-	p := prefs{KeepRepo: true, KeepHidden: true, GlobalTarget: false}
+	p := prefs{bools: map[ConfigOption]bool{OptBKeepRepo: true, OptBKeepHidden: true, OptBUseGlobalTgt: false}}
 	//1. run init
 	temp := initForTest(t)
 	//2. get selected spec

--- a/dscore/components.go
+++ b/dscore/components.go
@@ -148,9 +148,14 @@ func pathComponentEqual(pc, pc2 pathComponent) bool {
 
 // specEqual compares two cfg params for equality.
 // standalone function to ensure compatible with slices.EqualFunc
+// BUG: PREF CHANGE
 func specEqual(S, S2 Spec) bool {
 	return S.Alias == S2.Alias && S.Overrides == S2.Overrides && S.Ctype == S2.Ctype &&
 		slices.EqualFunc(S.Sources, S2.Sources, pathComponentEqual) &&
 		slices.EqualFunc(S.Targets, S2.Targets, pathComponentEqual) &&
 		slices.Equal(S.Ignorepat, S2.Ignorepat)
+}
+
+func prefsEqual(p, p2 prefs) bool {
+
 }

--- a/dscore/components.go
+++ b/dscore/components.go
@@ -3,6 +3,7 @@ package dscore
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -148,14 +149,14 @@ func pathComponentEqual(pc, pc2 pathComponent) bool {
 
 // specEqual compares two cfg params for equality.
 // standalone function to ensure compatible with slices.EqualFunc
-// BUG: PREF CHANGE
 func specEqual(S, S2 Spec) bool {
-	return S.Alias == S2.Alias && S.Overrides == S2.Overrides && S.Ctype == S2.Ctype &&
+	return S.Alias == S2.Alias && S.Ctype == S2.Ctype &&
 		slices.EqualFunc(S.Sources, S2.Sources, pathComponentEqual) &&
 		slices.EqualFunc(S.Targets, S2.Targets, pathComponentEqual) &&
-		slices.Equal(S.Ignorepat, S2.Ignorepat)
+		slices.Equal(S.Ignorepat, S2.Ignorepat) &&
+		S.Overrides.equal(S2.Overrides)
 }
 
 func prefsEqual(p, p2 prefs) bool {
-
+	return maps.Equal(p.bools, p2.bools)
 }

--- a/dscore/dsconfig.go
+++ b/dscore/dsconfig.go
@@ -2,6 +2,7 @@ package dscore
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -68,27 +69,98 @@ type globalModify struct {
 // !TODO:(hi-refactor) Change to use maps for prefs. Either make prefs a map or make prefs contain maps
 // - This will majorly simplify working with config options
 type prefs struct {
-	boolOpts     map[ConfigOption]bool
-	KeepRepo     bool `toml:"KeepRepo"`
-	KeepHidden   bool `toml:"KeepHidden"` //unused in 0.1
-	GlobalTarget bool `toml:"GlobalTarget"`
+	bools map[ConfigOption]bool
 	//TODO: symlink handling + symlink preference
 }
 
-/*
-	NOTE:FROM DOCS:
+// ╭─────────────────────────────────────────────────────────╮
+// │                     CONFIG OPTIONS                      │
+// ╰─────────────────────────────────────────────────────────╯
 
-|If the "omitempty" option is present the following value will be skipped:
-| -> arrays, slices, maps, and string with len of 0, struct with all zero values, bool false
-|+ALSO If omitzero is given all int and float types with a value of 0 will be skipped.
-| ( start iota at 1 with _ = iota to get past this)
-*/
+// uses ConfigOption index
+type ConfigOption int
 
-// prefs holds preferences for component-based operations
-// used scoped globally or to individual components/parents
-// type globalPrefs struct {
-// 	SelectNewSpec bool `toml:"SelectNewSpec"`
-// }
+// TODO:(mid-feat) better system (when do patterns/regex)
+
+// ── ConfigOptions ───────────────────────────────────────────────────
+
+const (
+	NotAnOption ConfigOption = iota - 1
+	OptBKeepRepo
+	OptBKeepHidden
+	OptBUseGlobalTgt
+	OptBCopyFiles
+	OptBCopyAllDirs
+	OptSGlobalTargetPath
+)
+
+// BoolOptions is a list containing all bool-value ConfigOptions
+// requires all val == index
+var BoolOptions = []ConfigOption{0, 1, 2, 3, 4}
+
+// StringOptions is a list containing all string-value ConfigOptions
+// requires all val == index + len(BoolOptions)
+var StringOptions = []ConfigOption{5}
+
+// var AllOptions = append(BoolOptions,StringOptions...)
+
+// optionCount provides the total length of the ConfigOption enum
+var optionCount = len(BoolOptions) + len(StringOptions)
+
+var PrefIdentifiers = [][]string{
+	{"keeprepo", "keep-repo", "keep_repo", "repo"},
+	{"keephidden", "keep-hidden", "keep_hidden", "hidden"},
+	{
+		"useglobaltarget", "use-global-target", "use_global_target",
+		"useglobaltgt", "use-globaltarget",
+		"globaltarget", "use-global",
+	},
+	{"copyfiles", "copy-files", "copy_files", "docopy"},
+	{
+		"alldirs", "all-dirs", "all_dirs",
+		"alldir", "all-dir", "all_dir",
+		"copyalldirs", "copy-all-dirs", "copy-alldir",
+	},
+	{"globaltargetpath", "targetpath", "global_target_path", "global-target-path"},
+}
+
+func (c ConfigOption) Text() string {
+	switch c {
+	case OptBKeepHidden:
+		return "KeepHidden"
+	case OptBKeepRepo:
+		return "KeepRepo"
+	case OptBUseGlobalTgt:
+		return "UseGlobalTarget"
+	case OptBCopyFiles:
+		return "CopyFiles"
+	case OptBCopyAllDirs:
+		return "CopyAllDirs"
+	case OptSGlobalTargetPath:
+		return "GlobalTargetPath"
+	}
+	return ("NotAnOption")
+}
+
+// OptionID returns the ConfigOption that optName corresponds to within PrefIdentifiers.
+//
+// optName is run through quickclean() before checking available values.
+func OptionID(optName string) ConfigOption {
+	//OptionID relies on having ConfigOption Enum values match PrefIdentifiers index
+	for i := range PrefIdentifiers {
+		if slices.Contains(PrefIdentifiers[i], quickclean(optName)) {
+			return ConfigOption(i)
+		}
+
+	}
+	return NotAnOption
+}
+
+func IsBoolOption(opt ConfigOption) bool { return slices.Contains(BoolOptions, opt) }
+
+func IsStringOption(opt ConfigOption) bool { return slices.Contains(StringOptions, opt) }
+
+// ──────────────────────────────────────────────────────────────────────
 
 func (G *globals) Detail() string {
 	lines := make([]string, 1, 32)
@@ -115,15 +187,15 @@ Globals Log (instance):
 }
 
 func (p prefs) Detail() string {
-	return fmt.Sprintf(`Prefs:
-	Keep Repo: %t
-	Keep Hidden Files: %t
-	Use Global Target: %t`, p.KeepRepo, p.KeepHidden, p.GlobalTarget)
+	out := ""
+	for k, v := range p.bools {
+		out = fmt.Sprintf("%s\n%s:%t", out, k.Text(), v)
+	}
+	return out
 }
 
 func (p prefs) equal(p2 prefs) bool {
-	return p.KeepHidden == p2.KeepHidden && p.KeepRepo == p2.KeepRepo &&
-		p.GlobalTarget == p2.GlobalTarget
+	return maps.Equal(p.bools, p2.bools)
 }
 
 // TempGlob exists to store new global data temporarily during runtime
@@ -135,8 +207,10 @@ func (G *globals) decodeRawData() {
 	if err != nil {
 		panic(fmt.Errorf("Error in dscore DecodeRawData() from data toml\n%w", err))
 	}
+	//TODO:(VO.1) REMOVE UNUSED
 	G.md = md //? Is this used at all
 
+	// don't remember what this one is about
 	//TODO: run CheckDataDecode on debug flag
 	//CheckDataDecode(G.data, md)
 }

--- a/dscore/dsconfig.go
+++ b/dscore/dsconfig.go
@@ -68,6 +68,7 @@ type globalModify struct {
 // !TODO:(hi-refactor) Change to use maps for prefs. Either make prefs a map or make prefs contain maps
 // - This will majorly simplify working with config options
 type prefs struct {
+	boolOpts     map[ConfigOption]bool
 	KeepRepo     bool `toml:"KeepRepo"`
 	KeepHidden   bool `toml:"KeepHidden"` //unused in 0.1
 	GlobalTarget bool `toml:"GlobalTarget"`

--- a/dscore/dsconfig.go
+++ b/dscore/dsconfig.go
@@ -155,10 +155,8 @@ func OptionID(optName string) ConfigOption {
 	}
 	return NotAnOption
 }
-
-func IsBoolOption(opt ConfigOption) bool { return slices.Contains(BoolOptions, opt) }
-
-func IsStringOption(opt ConfigOption) bool { return slices.Contains(StringOptions, opt) }
+func OptionIsBool(opt ConfigOption) bool   { return slices.Contains(BoolOptions, opt) }
+func OptionIsString(opt ConfigOption) bool { return slices.Contains(StringOptions, opt) }
 
 // ──────────────────────────────────────────────────────────────────────
 

--- a/dscore/dsconfig_test.go
+++ b/dscore/dsconfig_test.go
@@ -26,3 +26,28 @@ func TestStringOps(t *testing.T) {
 	t.Fail()
 
 }
+
+func TestConfigOptionOrder(t *testing.T) {
+	countFailures := 0
+
+	all := append(BoolOptions, StringOptions...)
+	for i, o := range all {
+		indexFail := false
+		icfgopt := ConfigOption(i)
+		itext := icfgopt.Text()
+		if icfgopt != o {
+			t.Errorf("ConfigOption(%d) = %s, should equal %s", i, itext, o.Text())
+			indexFail = true
+		}
+		l := OptionID(strings.ToLower(itext))
+		if l != icfgopt {
+			t.Errorf("Get ID: Input [%d]'%s' - Got [%d]'%s' ", i, itext, int(l), l.Text())
+			indexFail = true
+		}
+
+		if indexFail {
+			countFailures++
+		}
+	}
+	t.Logf("Checked ConfigOption System: %d failures.", countFailures)
+}

--- a/dscore/globalModify.go
+++ b/dscore/globalModify.go
@@ -202,9 +202,19 @@ func (gm *globalModify) ChangeSpecAlias(spec *Spec, newAlias string) bool {
 	spec.Alias = newAlias
 	return true
 }
+
 func (gm *globalModify) specByIndex(i int) *Spec {
 	if i < len(gm.Specs) {
 		return &gm.globalData.Specs[i]
+	}
+	return nil
+}
+func (gm *globalModify) SetSpecOverride(s *Spec, opt ConfigOption, val bool) {}
+
+func (gm *globalModify) SetSpecOverridesMap(s *Spec, newValues map[string]bool) error {
+	e := s.Overrides.setOptMap(newValues)
+	if e != nil {
+		return e
 	}
 	return nil
 }
@@ -221,7 +231,7 @@ func (gd *globalData) findAliasIndex(alias string) int {
 	return -1
 }
 
-// SetOptMap will modify all prefs/overrides with a key assigned in mpref.
+// setOptMap will modify all prefs/overrides with a key assigned in mpref.
 // keys are not case-sensitive, and all spaces are removed.
 // Accepted keys are:
 //   - Keep Git Repo: keeprepo | keep-repo | keep_repo | repo
@@ -229,7 +239,7 @@ func (gd *globalData) findAliasIndex(alias string) int {
 //   - Use Global Target:  globaltarget | global-target | global_target | globaltgt
 //
 // Returns ErrBadKey if the key does not match an acceptable input. Otherwise, returns nil
-func (p *prefs) SetOptMap(mpref map[string]bool) error {
+func (p *prefs) setOptMap(mpref map[string]bool) error {
 	var fails string
 	for k, b := range mpref {
 		set := p.setByName(k, b)

--- a/dscore/globalModify.go
+++ b/dscore/globalModify.go
@@ -209,16 +209,32 @@ func (gm *globalModify) specByIndex(i int) *Spec {
 	}
 	return nil
 }
-func (gm *globalModify) SetSpecOverride(s *Spec, opt ConfigOption, val bool) {}
 
-func (gm *globalModify) SetSpecOverridesMap(s *Spec, newValues map[string]bool) error {
-	e := s.Overrides.setOptMap(newValues)
-	if e != nil {
-		return e
+// TODO:(mid-refactor/system) re-work SetSpecOverrides/setOptMap to take into account OverrideOn and other non-prefs settings.
+// Should function similarly or same to setting GlobalTargetPath
+
+func (gm *globalModify) SetSpecOverridesMap(s *Spec, newValues map[string]bool) []string {
+	fails := s.Overrides.setOptMap(newValues)
+	for i, f := range fails {
+		// Check to see if
+		if matchOverrideOn(f) {
+			s.OverrideOn = newValues[f]
+			fails = slices.Delete(fails, i, i+1)
+			break
+		}
 	}
-	return nil
+	return fails
 }
 
+func matchOverrideOn(t string) bool { return strings.Contains("override", strings.ToLower(t)) }
+
+func (gm *globalModify) SetSpecEnableOverrides(s *Spec, enable bool) bool {
+	if s.OverrideOn != enable {
+		s.OverrideOn = enable
+		return true
+	}
+	return false
+}
 func (gm *globalModify) SelectedSpec() *Spec { return gm.specByIndex(gm.Selected) }
 
 // findAliasIndex searches for alias within []Specs
@@ -238,19 +254,18 @@ func (gd *globalData) findAliasIndex(alias string) int {
 //   - Keep other hidden: keephidden | keep-hidden | keep_hidden |  hidden
 //   - Use Global Target:  globaltarget | global-target | global_target | globaltgt
 //
-// Returns ErrBadKey if the key does not match an acceptable input. Otherwise, returns nil
-func (p *prefs) setOptMap(mpref map[string]bool) error {
-	var fails string
+// Returns list of strings that failed to correspond to an option
+func (p *prefs) setOptMap(mpref map[string]bool) []string {
+	fails := make([]string, 0, len(mpref))
 	for k, b := range mpref {
 		set := p.setByName(k, b)
 		if !set {
-			fails = fails + ", " + k
+			fails = append(fails, k)
+		} else {
+			//IDEA: Try stripping map of values that have been written with no return.
 		}
 	}
-	if len(fails) > 0 {
-		return fmt.Errorf("failures: (%s) - error %w", fails, ErrBadKey)
-	}
-	return nil
+	return fails
 }
 
 func (p *prefs) setByName(name string, val bool) bool {
@@ -262,12 +277,11 @@ func (p *prefs) setByName(name string, val bool) bool {
 
 func (p *prefs) setOpt(opt ConfigOption, val bool) bool {
 	optVal, exist := p.bools[opt]
-	switch {
-	case exist && val != optVal:
-		tempData.Modify()
-		p.bools[opt] = val
-		return true
-	case exist:
+	if exist {
+		if val != optVal {
+			tempData.Modify()
+			p.bools[opt] = val
+		}
 		return true
 	}
 	return false

--- a/dscore/globalModify.go
+++ b/dscore/globalModify.go
@@ -129,25 +129,43 @@ func (gm *globalModify) DeleteSpec(sptr *Spec) bool {
 	return false
 }
 
+// ╭─────────────────────────────────────────────────────────╮
+// │                     CONFIG OPTIONS                      │
+// ╰─────────────────────────────────────────────────────────╯
+var (
+	PrefNameKeepRepo         = []string{"keeprepo", "keep-repo", "keep_repo", "repo"}
+	PrefNameKeepHidden       = []string{"keephidden", "keep-hidden", "keep_hidden", "hidden"}
+	PrefNameUseGlobalTarget  = []string{"useglobaltarget", "useglobaltgt", "use-global", "use-globaltarget", "use_global_target", "use-global-target", "globaltarget"}
+	PrefNameGlobalTargetPath = []string{"globaltargetpath", "targetpath", "global_target_path", "global-target-path"}
+	PrefNameCopyFiles        = []string{"copyfiles", "copy-files", "copy_files", "docopy"}
+	PrefNameCopyAllDirs      = []string{"alldirs", "all-dirs", "all_dirs", "alldir", "all-dir", "all_dir", "copyalldirs", "copy-all-dirs", "copy-alldir"}
+)
+
 type ConfigOption int
 
 const (
-	OptBoolKeepRepo ConfigOption = iota
-	OptBoolUseGlobalTarget
-	OptBoolKeepHidden
-	OptStringGlobalTargetPath
+	OptBKeepRepo ConfigOption = iota
+	OptBUseGlobalTgt
+	OptBKeepHidden
+	OptBCopyAllDirs
+	OptBCopyFiles
+	OptSGlobalTargetPath
 	optionCount
 )
 
 func (c ConfigOption) Text() string {
 	switch c {
-	case OptBoolKeepHidden:
+	case OptBKeepHidden:
 		return "KeepHidden"
-	case OptBoolKeepRepo:
+	case OptBKeepRepo:
 		return "KeepRepo"
-	case OptBoolUseGlobalTarget:
+	case OptBUseGlobalTgt:
 		return "UseGlobalTarget"
-	case OptStringGlobalTargetPath:
+	case OptBCopyFiles:
+		return "CopyFiles"
+	case OptBCopyAllDirs:
+		return "CopyNoFiles"
+	case OptSGlobalTargetPath:
 		return "SetGlobalTargetPath"
 	}
 	return ("NotAnOption")
@@ -156,14 +174,17 @@ func (c ConfigOption) Text() string {
 func OptionID(optName string) ConfigOption {
 	switch {
 	case slices.Contains(PrefNameKeepRepo, optName):
-		return OptBoolKeepRepo
+		return OptBKeepRepo
 	case slices.Contains(PrefNameKeepHidden, optName):
-		return OptBoolKeepHidden
+		return OptBKeepHidden
 	case slices.Contains(PrefNameUseGlobalTarget, optName):
-		return OptBoolUseGlobalTarget
+		return OptBUseGlobalTgt
 	case slices.Contains(PrefNameGlobalTargetPath, optName):
-		return OptStringGlobalTargetPath
-
+		return OptSGlobalTargetPath
+	case slices.Contains(PrefNameCopyFiles, optName):
+		return OptBCopyFiles
+	case slices.Contains(PrefNameCopyAllDirs, optName):
+		return OptBCopyAllDirs
 	}
 	return 0
 }
@@ -182,15 +203,15 @@ func (gm *globalModify) SetNamedOptionString(optName string, newValue string) er
 
 func (gm *globalModify) SetOptionBool(opt ConfigOption, newValue bool) bool {
 	switch opt {
-	case OptBoolUseGlobalTarget:
+	case OptBUseGlobalTgt:
 		tempData.Modify()
 		gm.Prefs.GlobalTarget = newValue
 		return true
-	case OptBoolKeepRepo:
+	case OptBKeepRepo:
 		tempData.Modify()
 		gm.Prefs.KeepRepo = newValue
 		return true
-	case OptBoolKeepHidden:
+	case OptBKeepHidden:
 		tempData.Modify()
 		gm.Prefs.KeepHidden = newValue
 		return true
@@ -202,7 +223,7 @@ func (gm *globalModify) SetOptionBool(opt ConfigOption, newValue bool) bool {
 // SetOptionString
 func (gm *globalModify) SetOptionString(opt ConfigOption, newValue string) error {
 	switch opt {
-	case OptStringGlobalTargetPath:
+	case OptSGlobalTargetPath:
 		tempData.Modify()
 		newpath, e := pops.Abs(newValue)
 		if e != nil {
@@ -288,11 +309,6 @@ func (p *prefs) SetM(mpref map[string]bool) error {
 	return nil
 }
 
-var PrefNameKeepRepo = []string{"keeprepo", "keep-repo", "keep_repo", "repo"}
-var PrefNameKeepHidden = []string{"keephidden", "keep-hidden", "keep_hidden", "hidden"}
-var PrefNameUseGlobalTarget = []string{"useglobaltarget", "useglobaltgt", "use-global", "use-globaltarget", "use_global_target", "use-global-target", "globaltarget"}
-var PrefNameGlobalTargetPath = []string{"globaltargetpath", "targetpath", "global_target_path", "global-target-path"}
-
 func (p *prefs) SetByName(name string, val bool) error {
 	name = quickclean(name)
 	switch {
@@ -313,13 +329,13 @@ func (p *prefs) SetByName(name string, val bool) error {
 
 func (p *prefs) SetOpt(opt ConfigOption, val bool) {
 	switch opt {
-	case OptBoolKeepHidden:
+	case OptBKeepHidden:
 		tempData.Modify()
 		p.KeepHidden = val
-	case OptBoolKeepRepo:
+	case OptBKeepRepo:
 		tempData.Modify()
 		p.KeepRepo = val
-	case OptBoolUseGlobalTarget:
+	case OptBUseGlobalTgt:
 		tempData.Modify()
 		p.GlobalTarget = val
 	}

--- a/dscore/globalModify.go
+++ b/dscore/globalModify.go
@@ -129,66 +129,6 @@ func (gm *globalModify) DeleteSpec(sptr *Spec) bool {
 	return false
 }
 
-// ╭─────────────────────────────────────────────────────────╮
-// │                     CONFIG OPTIONS                      │
-// ╰─────────────────────────────────────────────────────────╯
-var (
-	PrefNameKeepRepo         = []string{"keeprepo", "keep-repo", "keep_repo", "repo"}
-	PrefNameKeepHidden       = []string{"keephidden", "keep-hidden", "keep_hidden", "hidden"}
-	PrefNameUseGlobalTarget  = []string{"useglobaltarget", "useglobaltgt", "use-global", "use-globaltarget", "use_global_target", "use-global-target", "globaltarget"}
-	PrefNameGlobalTargetPath = []string{"globaltargetpath", "targetpath", "global_target_path", "global-target-path"}
-	PrefNameCopyFiles        = []string{"copyfiles", "copy-files", "copy_files", "docopy"}
-	PrefNameCopyAllDirs      = []string{"alldirs", "all-dirs", "all_dirs", "alldir", "all-dir", "all_dir", "copyalldirs", "copy-all-dirs", "copy-alldir"}
-)
-
-type ConfigOption int
-
-const (
-	OptBKeepRepo ConfigOption = iota
-	OptBUseGlobalTgt
-	OptBKeepHidden
-	OptBCopyAllDirs
-	OptBCopyFiles
-	OptSGlobalTargetPath
-	optionCount
-)
-
-func (c ConfigOption) Text() string {
-	switch c {
-	case OptBKeepHidden:
-		return "KeepHidden"
-	case OptBKeepRepo:
-		return "KeepRepo"
-	case OptBUseGlobalTgt:
-		return "UseGlobalTarget"
-	case OptBCopyFiles:
-		return "CopyFiles"
-	case OptBCopyAllDirs:
-		return "CopyNoFiles"
-	case OptSGlobalTargetPath:
-		return "SetGlobalTargetPath"
-	}
-	return ("NotAnOption")
-}
-
-func OptionID(optName string) ConfigOption {
-	switch {
-	case slices.Contains(PrefNameKeepRepo, optName):
-		return OptBKeepRepo
-	case slices.Contains(PrefNameKeepHidden, optName):
-		return OptBKeepHidden
-	case slices.Contains(PrefNameUseGlobalTarget, optName):
-		return OptBUseGlobalTgt
-	case slices.Contains(PrefNameGlobalTargetPath, optName):
-		return OptSGlobalTargetPath
-	case slices.Contains(PrefNameCopyFiles, optName):
-		return OptBCopyFiles
-	case slices.Contains(PrefNameCopyAllDirs, optName):
-		return OptBCopyAllDirs
-	}
-	return 0
-}
-
 func (gm *globalModify) Modify() { gm.Modified = true }
 
 // SetOptionBool sets selected configOption opt to newValue.
@@ -202,21 +142,15 @@ func (gm *globalModify) SetNamedOptionString(optName string, newValue string) er
 }
 
 func (gm *globalModify) SetOptionBool(opt ConfigOption, newValue bool) bool {
-	switch opt {
-	case OptBUseGlobalTgt:
-		tempData.Modify()
-		gm.Prefs.GlobalTarget = newValue
+	val, exist := gm.Prefs.bools[opt]
+	switch {
+	case exist && val != newValue:
+		gm.Modify()
+		gm.Prefs.bools[opt] = newValue
 		return true
-	case OptBKeepRepo:
-		tempData.Modify()
-		gm.Prefs.KeepRepo = newValue
-		return true
-	case OptBKeepHidden:
-		tempData.Modify()
-		gm.Prefs.KeepHidden = newValue
+	case exist:
 		return true
 	}
-
 	return false
 }
 
@@ -287,7 +221,7 @@ func (gd *globalData) findAliasIndex(alias string) int {
 	return -1
 }
 
-// SetM will modify all prefs/overrides with a key assigned in mpref.
+// SetOptMap will modify all prefs/overrides with a key assigned in mpref.
 // keys are not case-sensitive, and all spaces are removed.
 // Accepted keys are:
 //   - Keep Git Repo: keeprepo | keep-repo | keep_repo | repo
@@ -295,11 +229,11 @@ func (gd *globalData) findAliasIndex(alias string) int {
 //   - Use Global Target:  globaltarget | global-target | global_target | globaltgt
 //
 // Returns ErrBadKey if the key does not match an acceptable input. Otherwise, returns nil
-func (p *prefs) SetM(mpref map[string]bool) error {
+func (p *prefs) SetOptMap(mpref map[string]bool) error {
 	var fails string
 	for k, b := range mpref {
-		e := p.SetByName(k, b)
-		if e != nil {
+		set := p.setByName(k, b)
+		if !set {
 			fails = fails + ", " + k
 		}
 	}
@@ -309,45 +243,38 @@ func (p *prefs) SetM(mpref map[string]bool) error {
 	return nil
 }
 
-func (p *prefs) SetByName(name string, val bool) error {
-	name = quickclean(name)
-	switch {
-	case slices.Contains(PrefNameKeepRepo, name):
-		tempData.Modify()
-		p.KeepRepo = val
-	case slices.Contains(PrefNameKeepHidden, name):
-		tempData.Modify()
-		p.KeepHidden = val
-	case slices.Contains(PrefNameUseGlobalTarget, name):
-		tempData.Modify()
-		p.GlobalTarget = val
-	default:
-		return ErrBadKey
+func (p *prefs) setByName(name string, val bool) bool {
+	if opt := OptionID(name); opt != NotAnOption {
+		return p.setOpt(opt, val)
 	}
-	return nil
+	return false
 }
 
-func (p *prefs) SetOpt(opt ConfigOption, val bool) {
-	switch opt {
-	case OptBKeepHidden:
+func (p *prefs) setOpt(opt ConfigOption, val bool) bool {
+	optVal, exist := p.bools[opt]
+	switch {
+	case exist && val != optVal:
 		tempData.Modify()
-		p.KeepHidden = val
-	case OptBKeepRepo:
-		tempData.Modify()
-		p.KeepRepo = val
-	case OptBUseGlobalTgt:
-		tempData.Modify()
-		p.GlobalTarget = val
+		p.bools[opt] = val
+		return true
+	case exist:
+		return true
 	}
+	return false
 }
 
 func (gd *globalData) SetGlobalTargetPath(path string) { gd.GlobalTargetPath = pops.CleanPath(path) }
 
+// TODO:(V0.0.1) Delete
 func (p *prefs) OverwriteRaw(newp prefs) error {
 	if !p.equal(newp) {
-		p.KeepHidden = newp.KeepHidden
-		p.KeepRepo = newp.KeepRepo
-		p.GlobalTarget = newp.GlobalTarget
+		for co := range p.bools {
+			delete(p.bools, co)
+		}
+		for k, v := range newp.bools {
+			p.bools[k] = v
+		}
+
 	}
 	return nil
 }

--- a/dscore/globalModify_test.go
+++ b/dscore/globalModify_test.go
@@ -123,9 +123,9 @@ func TestGlobalEncodeSoftAssign(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = st1.Overrides.setOptMap(map[string]bool{"globaltarget": true})
-	if err != nil {
-		t.Error(err)
+	failed := st1.Overrides.setOptMap(map[string]bool{"globaltarget": true})
+	if len(failed) > 0 {
+		t.Error("failed set option globaltarget")
 	}
 	if tmp.getSpec("gamer") == nil {
 		t.Error("nil pointer from created spec")

--- a/dscore/globalModify_test.go
+++ b/dscore/globalModify_test.go
@@ -123,7 +123,7 @@ func TestGlobalEncodeSoftAssign(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = st1.Overrides.SetM(map[string]bool{"globaltarget": true})
+	err = st1.Overrides.setOptMap(map[string]bool{"globaltarget": true})
 	if err != nil {
 		t.Error(err)
 	}

--- a/dscore/globals.go
+++ b/dscore/globals.go
@@ -44,14 +44,13 @@ var gd = globals{
 	loaded: false,
 	data: globalData{
 		Prefs: prefs{
-			boolOpts: map[ConfigOption]bool{
+			bools: map[ConfigOption]bool{
 				OptBKeepHidden:   true,
 				OptBKeepRepo:     true,
 				OptBUseGlobalTgt: true,
+				OptBCopyAllDirs:  false,
+				OptBCopyFiles:    true,
 			},
-			KeepRepo:     true,
-			KeepHidden:   true,
-			GlobalTarget: true,
 		},
 		GlobalTargetPath: "~\\dotstrike\\globalTarget\\", // this doesnt work until transformed in CoreConfig.
 		Specs:            []Spec{},

--- a/dscore/globals.go
+++ b/dscore/globals.go
@@ -44,6 +44,11 @@ var gd = globals{
 	loaded: false,
 	data: globalData{
 		Prefs: prefs{
+			boolOpts: map[ConfigOption]bool{
+				OptBKeepHidden:   true,
+				OptBKeepRepo:     true,
+				OptBUseGlobalTgt: true,
+			},
 			KeepRepo:     true,
 			KeepHidden:   true,
 			GlobalTarget: true,

--- a/dscore/spec.go
+++ b/dscore/spec.go
@@ -104,10 +104,7 @@ func (S *Spec) Detail() string {
 	// ── Overrides ────────────────────────────
 	lines = append(lines, fmt.Sprintf("Overrides Enabled: %t", S.OverrideOn))
 	if !S.Overrides.equal(gd.data.Prefs) {
-		lines = append(lines, fmt.Sprintf(`Overrides:
-	Keep Repo: %t
-	Keep Hidden Files: %t
-	Use Global Target: %t`, S.Overrides.KeepRepo, S.Overrides.KeepHidden, S.Overrides.GlobalTarget))
+		lines = append(lines, fmt.Sprintf("Overrides:\n%s", S.Overrides.Detail()))
 	}
 
 	// ── Ignores ──────────────────────────────
@@ -373,6 +370,7 @@ func (S *Spec) CheckAddMultiplePaths(paths []string, isSource bool) []bool {
 // 		return fmt.Errorf("spec not initialized: %s", S.Alias)
 // 	}
 // 	copymachine := pops.GetCopierMaschine()
+
 // 	for y, tgt := range S.Targets {
 // 		for x, src := range S.Sources {
 // 			job := copymachine.NewJob(S.Alias+"."+fmt.Sprintf("%d", x)+"."+fmt.Sprintf("%d", y), src.Path, tgt.Path)

--- a/dscore/spec.go
+++ b/dscore/spec.go
@@ -18,6 +18,8 @@ func recoverReturn(explainer string) bool {
 	return false
 }
 
+//TODO: Replace overrides with map/maps?
+
 // Primary user data structure; contains info required to perform a dircopy operation
 // Methods:
 //   - Detail(): nice printable spec detail string

--- a/dscore/utilities.go
+++ b/dscore/utilities.go
@@ -1,11 +1,12 @@
 package dscore
 
-import "strings"
-
+// StringToBool tries to get a bool from string
+// if succeeds, returns found value (*true or *false)
+// if fails to match with any option, returns nil
 func StringToBool(text string) *bool {
 	var t bool = true
 	var f bool = false
-	text = strings.TrimSpace(strings.ToLower(text))
+	text = quickclean(text)
 	switch text {
 	case "true", "1", "yes", "t", "y", "on", "enabled":
 		return &t
@@ -17,6 +18,7 @@ func StringToBool(text string) *bool {
 	}
 }
 
+// TODO: clean up; no use for these I can think of.
 //
 // // StringToBoolFalsy returns true only if text == "true" (case insensitive, spaces removed)
 // // returns false in any other case
@@ -28,4 +30,4 @@ func StringToBool(text string) *bool {
 // 	return false
 // }
 //
-// func StringBoolTruthyFalsy(text string) bool { return len(text) > 0 } //TODO: delete
+// func StringBoolTruthyFalsy(text string) bool { return len(text) > 0 }

--- a/main_test.go
+++ b/main_test.go
@@ -64,8 +64,19 @@ func TestPrintEnum(t *testing.T) {
 	t.Logf("[%+v]", dscore.OptBKeepRepo)
 	t.Logf("[%#v]", dscore.OptBKeepRepo)
 	t.Logf("[%#+v]", dscore.OptBKeepRepo)
-	t.Logf("[%n]", dscore.OptBKeepRepo)
+	t.Logf("[%x]", dscore.OptBKeepRepo)
 }
+
+// func TestIndexBrainpower(t *testing.T) {
+// 	si := []int{0, 1, 2, 3, 4, 5, 6, 7}
+// 	siw := []string{"big", "stuff", "we", "are", "doing", "things", "DONT PRINT THIS"}
+// 	for i := 0; i < len(si)-1; i += 2 {
+// 		t.Logf("ints:[%d:%d]", si[i], si[i+1])
+// 	}
+// 	for i := 0; i < len(siw)-1; i += 2 {
+// 		t.Logf("strings:[%s:%s]", siw[i], siw[i+1])
+// 	}
+// }
 
 func TestIndexString(t *testing.T) {
 	text := lesstext

--- a/main_test.go
+++ b/main_test.go
@@ -60,11 +60,11 @@ func retCheck(fpath string) error {
 }
 func TestPrintEnum(t *testing.T) {
 	t.Log("printing dscore.OptBoolKeepRepo (v, +v, #v, s maybe):")
-	t.Logf("[%v]", dscore.OptBoolKeepRepo)
-	t.Logf("[%+v]", dscore.OptBoolKeepRepo)
-	t.Logf("[%#v]", dscore.OptBoolKeepRepo)
-	t.Logf("[%#+v]", dscore.OptBoolKeepRepo)
-	t.Logf("[%n]", dscore.OptBoolKeepRepo)
+	t.Logf("[%v]", dscore.OptBkeepRepo)
+	t.Logf("[%+v]", dscore.OptBkeepRepo)
+	t.Logf("[%#v]", dscore.OptBkeepRepo)
+	t.Logf("[%#+v]", dscore.OptBkeepRepo)
+	t.Logf("[%n]", dscore.OptBkeepRepo)
 }
 
 func TestIndexString(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -60,11 +60,11 @@ func retCheck(fpath string) error {
 }
 func TestPrintEnum(t *testing.T) {
 	t.Log("printing dscore.OptBoolKeepRepo (v, +v, #v, s maybe):")
-	t.Logf("[%v]", dscore.OptBkeepRepo)
-	t.Logf("[%+v]", dscore.OptBkeepRepo)
-	t.Logf("[%#v]", dscore.OptBkeepRepo)
-	t.Logf("[%#+v]", dscore.OptBkeepRepo)
-	t.Logf("[%n]", dscore.OptBkeepRepo)
+	t.Logf("[%v]", dscore.OptBKeepRepo)
+	t.Logf("[%+v]", dscore.OptBKeepRepo)
+	t.Logf("[%#v]", dscore.OptBKeepRepo)
+	t.Logf("[%#+v]", dscore.OptBKeepRepo)
+	t.Logf("[%n]", dscore.OptBKeepRepo)
 }
 
 func TestIndexString(t *testing.T) {

--- a/pathops/moveops.go
+++ b/pathops/moveops.go
@@ -32,6 +32,26 @@ type copierMaschine struct {
 var cmachine copierMaschine = copierMaschine{JobQueue: make(map[string]*CopyJob)}
 var Copier = &cmachine
 
+// CopyJob prepares and executes the copy of all contents of PathIn to PathOut
+type CopyJob struct {
+	PathIn, PathOut string          // Root of copy source and destination (*or destination parent)
+	parentPathOut   string          // unused. populated on run if JobSettings.makeRootSubdir = true
+	fstack          []filecopy      // record of files copied
+	newDirs         map[string]bool //
+	ignore          IgnoreSet
+	OpErrors        []fs.PathError
+	JobSettings     copyConfig
+}
+
+// NOTE: unless explicitly stated, copyConfig values do not override ignores
+type copyConfig struct {
+	makeRootSubdir     bool // if true, appends base(PathIn) to PathOut
+	copyAllDirectories bool // copies directories regardless of whether files will be copied
+	noFiles            bool // does not copy files. Use for dry run, or enable copyAllDirectories to only copy directory structure
+	//DRY_RUN bool
+}
+
+// TODO:(low-refactor) move to function access only
 func GetCopierMaschine() *copierMaschine { return &cmachine }
 
 // NewJob creates a new job and adds to the JobQueue; returns a ptr to created job if successful


### PR DESCRIPTION
Implemented config command "cfg"
Provides ability to persistently modify global preferences and spec-local preference overrides
Restructured preferences; now stores preference values in a map with enum keys identifying the option
